### PR TITLE
Add logger option to configuration

### DIFF
--- a/lib/duty_calculator/client.rb
+++ b/lib/duty_calculator/client.rb
@@ -10,7 +10,7 @@ module DutyCalculator
         faraday.use Faraday::Response::ParseXml
         faraday.use Faraday::Response::Mashify
         faraday.use Faraday::Response::RaiseError unless DutyCalculator.configuration.debug
-        faraday.response :logger if DutyCalculator.configuration.debug
+        faraday.response :logger, DutyCalculator.configuration.logger
 
         faraday.adapter ::Faraday.default_adapter
       end

--- a/lib/duty_calculator/configuration.rb
+++ b/lib/duty_calculator/configuration.rb
@@ -1,10 +1,11 @@
 require "yaml"
-
+require 'logger'
 require "duty_calculator"
 
 module DutyCalculator
   class Configuration
-    attr_accessor :api_root, :api_version, :api_key, :api_base, :sandbox, :debug
+    attr_accessor :api_root, :api_version, :api_key, :api_base, :sandbox, :debug, :logger
+
 
     def initialize
       defaults = load_defaults
@@ -12,6 +13,7 @@ module DutyCalculator
       @api_version = defaults[:api_version]
       @sandbox = defaults[:sandbox]
       @debug = defaults[:debug]
+      @logger = ::Logger.new(STDOUT)
     end
 
     private


### PR DESCRIPTION
Word!
## Usage

``` ruby
DutyCalculator.configure do |config|
  config.api_key = Settings.duty_calculator
  config.sandbox = !Rails.env.production?
  config.debug = !Rails.env.production?
  config.logger = Rails.logger
end
```

@rheaton @BrainScraps 

![image 2015-04-01 at 1 46 30 pm](https://cloud.githubusercontent.com/assets/15386/6952365/3993303c-d876-11e4-8015-ecb0a17fe574.png)

fixes #6
